### PR TITLE
To fix the overlap problem TodayButtonLabel with DateLabel on iPhone 5.

### DIFF
--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -153,9 +153,13 @@ import UIKit
         todayButton.setTitle(todayButtonTitle, for: .normal)
         todayButton.setTitleColor(highlightColor, for: .normal)
         todayButton.addTarget(self, action: #selector(DateTimePicker.setToday), for: .touchUpInside)
-        todayButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 15)
+        todayButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 13)
+        todayButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        todayButton.titleLabel?.numberOfLines = 1
+        todayButton.titleLabel?.textAlignment = .right
         todayButton.isHidden = self.minimumDate.compare(Date()) == .orderedDescending || self.maximumDate.compare(Date()) == .orderedAscending
         let size = todayButton.sizeThatFits(CGSize(width: 0, height: 44.0)).width + 10.0
+       
         todayButton.frame = CGRect(x: contentView.frame.width - size, y: 0, width: size, height: 44)
         titleView.addSubview(todayButton)
         


### PR DESCRIPTION
The today button text "Today..." overlap with DateLabel text. The problem only appears on smaller size iPhone like iPhone 5. 
