### PR TITLE
Add months option

### DIFF
--- a/DateTimePicker/ViewController.swift
+++ b/DateTimePicker/ViewController.swift
@@ -21,6 +21,7 @@ class ViewController: UIViewController {
         picker.is12HourFormat = true
         picker.dateFormat = "hh:mm aa dd/MM/YYYY"
 //        picker.isTimePickerOnly = true
+        picker.includeMonth = false // if true, it shows FullDateCollectionViewCell with month at top
         picker.completionHandler = { date in
             let formatter = DateFormatter()
             formatter.dateFormat = "hh:mm aa dd/MM/YYYY"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Drag and drop folder `Source` to your project.
 
 
 ## Usage
-
 You can easily show and customize the component's colors
 
 ```Swift
@@ -33,6 +32,13 @@ picker.completionHandler = { date in
     // do something after tapping done
 }
 ```
+Dates displayed can be customized by passing in a minimum and maximum date when creating the picker. 
+```
+let min = minDate // can be Date() or another Date value
+let max = maxDate // can be Date() or another Date value
+let picker = DateTimePicker.show(selected: Date(), minimumDate: min, maximumDate: max)
+```
+If you need to show the month, set `picker.includeMonth = true`. The month will show up on the date card.
 
 ## Contributing
 

--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -110,6 +110,11 @@ import UIKit
             configureView()
         }
     }
+    public var includeMonth = false {
+        didSet {
+            configureView()
+        }
+    }
     
     public var timeZone = TimeZone.current
     public var completionHandler: ((Date)->Void)?
@@ -240,7 +245,11 @@ import UIKit
         dayCollectionView = UICollectionView(frame: CGRect(x: 0, y: 44, width: contentView.frame.width, height: 100), collectionViewLayout: layout)
         dayCollectionView.backgroundColor = daysBackgroundColor
         dayCollectionView.showsHorizontalScrollIndicator = false
-        dayCollectionView.register(DateCollectionViewCell.self, forCellWithReuseIdentifier: "dateCell")
+        if includeMonth {
+            dayCollectionView.register(FullDateCollectionViewCell.self, forCellWithReuseIdentifier: "dateCell")
+        }
+        else if includeMonth == false {
+            dayCollectionView.register(DateCollectionViewCell.self, forCellWithReuseIdentifier: "dateCell")}
         dayCollectionView.dataSource = self
         dayCollectionView.delegate = self
         dayCollectionView.isHidden = isTimePickerOnly
@@ -597,12 +606,20 @@ extension DateTimePicker: UICollectionViewDataSource, UICollectionViewDelegate {
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "dateCell", for: indexPath) as! DateCollectionViewCell
-        
-        let date = dates[indexPath.item]
-        cell.populateItem(date: date, highlightColor: highlightColor, darkColor: darkColor)
-        
-        return cell
+        if includeMonth {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "dateCell", for: indexPath) as! FullDateCollectionViewCell
+            let date = dates[indexPath.item]
+            cell.populateItem(date: date, highlightColor: highlightColor, darkColor: darkColor)
+
+            return cell
+        }
+        else {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "dateCell", for: indexPath) as! DateCollectionViewCell
+            let date = dates[indexPath.item]
+            cell.populateItem(date: date, highlightColor: highlightColor, darkColor: darkColor)
+
+            return cell
+        }
     }
     
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Source/FullDateCollectionViewCell.swift
+++ b/Source/FullDateCollectionViewCell.swift
@@ -1,0 +1,83 @@
+//
+//  FullDateCollectionViewCell.swift
+//  DateTimePicker
+//
+//  Created by Jess Chandler on 10/14/17.
+//  Copyright © 2017 ichigo. All rights reserved.
+//
+
+import UIKit
+
+class FullDateCollectionViewCell: UICollectionViewCell {
+    var monthLabel: UILabel!
+    var dayLabel: UILabel! // rgb(128,138,147)
+    var numberLabel: UILabel!
+    var darkColor = UIColor(red: 0, green: 22.0/255.0, blue: 39.0/255.0, alpha: 1)
+    var highlightColor = UIColor(red: 0/255.0, green: 199.0/255.0, blue: 194.0/255.0, alpha: 1)
+
+
+    override init(frame: CGRect) {
+
+        monthLabel = UILabel(frame: CGRect(x: 5, y: 5, width: frame.width - 10, height: 20))
+        monthLabel.font = UIFont.systemFont(ofSize: 10)
+        monthLabel.textAlignment = .center
+
+        dayLabel = UILabel(frame: CGRect(x: 5, y: 15, width: frame.width - 10, height: 20))
+        dayLabel.font = UIFont.systemFont(ofSize: 10)
+        dayLabel.textAlignment = .center
+
+        numberLabel = UILabel(frame: CGRect(x: 5, y: 30, width: frame.width - 10, height: 40))
+        numberLabel.font = UIFont.systemFont(ofSize: 25)
+        numberLabel.textAlignment = .center
+
+        super.init(frame: frame)
+
+        contentView.addSubview(monthLabel)
+        contentView.addSubview(dayLabel)
+        contentView.addSubview(numberLabel)
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 3
+        contentView.layer.masksToBounds = true
+        contentView.layer.borderWidth = 1
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            monthLabel.textColor = isSelected == true ? .white : darkColor
+            dayLabel.textColor = isSelected == true ? .white : darkColor.withAlphaComponent(0.5)
+            numberLabel.textColor = isSelected == true ? .white : darkColor
+            contentView.backgroundColor = isSelected == true ? highlightColor : .white
+            contentView.layer.borderWidth = isSelected == true ? 0 : 1
+        }
+    }
+
+    func populateItem(date: Date, highlightColor: UIColor, darkColor: UIColor) {
+        self.highlightColor = highlightColor
+        self.darkColor = darkColor
+
+        let mdateFormatter = DateFormatter()
+        mdateFormatter.dateFormat = "MMM"
+        monthLabel.text = mdateFormatter.string(from: date)
+        monthLabel.textColor = isSelected == true ? .white : darkColor
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "EEEE"
+        dayLabel.text = dateFormatter.string(from: date).uppercased()
+        dayLabel.textColor = isSelected == true ? .white : darkColor.withAlphaComponent(0.5)
+
+        let numberFormatter = DateFormatter()
+        numberFormatter.dateFormat = "d"
+        numberLabel.text = numberFormatter.string(from: date)
+        numberLabel.textColor = isSelected == true ? .white : darkColor
+
+
+
+        contentView.layer.borderColor = darkColor.withAlphaComponent(0.2).cgColor
+        contentView.backgroundColor = isSelected == true ? highlightColor : .white
+    }
+
+}


### PR DESCRIPTION
This allows the user to show the month at the top if desired by using a different date collection view cell, FullDateCollectionViewCell that includes a month displayed. This may be helpful for users who have date ranges that span a transition across months. 
When `picker.includeMonth = true`, appearance is like so: 
![screen shot 2017-10-14 at 07 23 37](https://user-images.githubusercontent.com/7316730/31568879-d8cbe354-b0b1-11e7-8a9e-bead02a33e7d.png)
