### PR TITLE
Close when tapping outside of content view

### DIFF
--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -224,8 +224,6 @@ public protocol DateTimePickerDelegate: class {
             let shadowView = UIView()
             shadowView.backgroundColor = UIColor.black.withAlphaComponent(0.3)
             shadowView.alpha = 1
-            let shadowViewTap = UITapGestureRecognizer(target: self, action: #selector(DateTimePicker.dismissView(sender:)))
-            shadowView.addGestureRecognizer(shadowViewTap)
             window.addSubview(shadowView)
             
             shadowView.translatesAutoresizingMaskIntoConstraints = false
@@ -272,6 +270,14 @@ public protocol DateTimePickerDelegate: class {
         }
         
         self.resetTime()
+    }
+	
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        let touch = touches.first
+        guard let location = touch?.location(in: self) else { return }
+        if !contentView.frame.contains(location) {
+            dismissView(sender: nil)
+        }
     }
     
     private func configureView() {

--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -255,7 +255,7 @@ public protocol DateTimePickerDelegate: class {
                 contentViewBottomConstraint.constant = self.contentHeight
                 UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0.8, options: .curveLinear, animations: {
                     // animate to hide pickerView
-		    shadowView. alpha = 0
+		    shadowView.alpha = 0
                     self.layoutIfNeeded()
                 }, completion: { (completed) in
                     self.removeFromSuperview()

--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -255,6 +255,7 @@ public protocol DateTimePickerDelegate: class {
                 contentViewBottomConstraint.constant = self.contentHeight
                 UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0.8, options: .curveLinear, animations: {
                     // animate to hide pickerView
+		    shadowView. alpha = 0
                     self.layoutIfNeeded()
                 }, completion: { (completed) in
                     self.removeFromSuperview()


### PR DESCRIPTION
There was a GestureRecognizer added to shadowView but this was seemingly blocked by contentView.

So removed the GestureRecognizer and used an alternate method.

Also added shadowView alpha to the remove animation to make it look a little smoother.