### PR TITLE
[Enhancement] [SPM] Bundle Resource

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/DateTimePicker.podspec
+++ b/DateTimePicker.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "DateTimePicker"
-  s.version      = "2.4.1"
+  s.version      = "2.5.0"
   s.summary      = "A nicer iOS UI component for picking date and time."
 
   s.description  = "DateTimePicker makes it easy to select date and time with an attractive looking component."
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.framework  = "UIKit"
 
   s.requires_arc = true
-  s.pod_target_xcconfig = { "SWIFT_VERSION" => "5.0" }
-  s.swift_version = "5.0"
+  s.pod_target_xcconfig = { "SWIFT_VERSION" => "5.3" }
+  s.swift_version = "5.3"
 
 end

--- a/DateTimePicker.xcodeproj/project.pbxproj
+++ b/DateTimePicker.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		2C788A1D2116AF2E00B26F02 /* FullDateCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BBF8171F91EAA2005D807B /* FullDateCollectionViewCell.swift */; };
 		2C788A1E2116AF2E00B26F02 /* StepCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE58808E1D9A5F2E000C93E3 /* StepCollectionViewFlowLayout.swift */; };
 		2C788A232116AFAD00B26F02 /* DateTimePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C788A222116AFAD00B26F02 /* DateTimePicker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		966066EE2530AF7000427563 /* Bundle+Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966066ED2530AF7000427563 /* Bundle+Resource.swift */; };
+		966066EF2530AF7000427563 /* Bundle+Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966066ED2530AF7000427563 /* Bundle+Resource.swift */; };
 		C8BBF8181F91EAA2005D807B /* FullDateCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BBF8171F91EAA2005D807B /* FullDateCollectionViewCell.swift */; };
 		DE20B66D23DACE1C009532AE /* DateTimePicker.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE29D3FA23DAC502007CC0F4 /* DateTimePicker.xib */; };
 		DE20B66F23DAE1E5009532AE /* FullDateCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE20B66E23DAE1E5009532AE /* FullDateCollectionViewCell.xib */; };
@@ -54,6 +56,7 @@
 		2C7889C32116AC4900B26F02 /* DateTimePicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DateTimePicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C7889C62116AC4A00B26F02 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2C788A222116AFAD00B26F02 /* DateTimePicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateTimePicker.h; sourceTree = "<group>"; };
+		966066ED2530AF7000427563 /* Bundle+Resource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Resource.swift"; sourceTree = "<group>"; };
 		C8BBF8171F91EAA2005D807B /* FullDateCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDateCollectionViewCell.swift; sourceTree = "<group>"; };
 		DE20B66E23DAE1E5009532AE /* FullDateCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FullDateCollectionViewCell.xib; sourceTree = "<group>"; };
 		DE29D3F223C1B2C1007CC0F4 /* DateTimePicker+UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateTimePicker+UITableView.swift"; sourceTree = "<group>"; };
@@ -113,13 +116,14 @@
 		DEF7C3781D8B9F590043D9C4 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				966066ED2530AF7000427563 /* Bundle+Resource.swift */,
 				DEF7C3791D8B9F590043D9C4 /* DateTimePicker.swift */,
-				C8BBF8171F91EAA2005D807B /* FullDateCollectionViewCell.swift */,
-				DE58808E1D9A5F2E000C93E3 /* StepCollectionViewFlowLayout.swift */,
-				DE29D3F223C1B2C1007CC0F4 /* DateTimePicker+UITableView.swift */,
-				DE29D3F423C1B301007CC0F4 /* DateTimePicker+CollectionView.swift */,
 				DE29D3FA23DAC502007CC0F4 /* DateTimePicker.xib */,
+				DE29D3F423C1B301007CC0F4 /* DateTimePicker+CollectionView.swift */,
+				DE29D3F223C1B2C1007CC0F4 /* DateTimePicker+UITableView.swift */,
+				C8BBF8171F91EAA2005D807B /* FullDateCollectionViewCell.swift */,
 				DE20B66E23DAE1E5009532AE /* FullDateCollectionViewCell.xib */,
+				DE58808E1D9A5F2E000C93E3 /* StepCollectionViewFlowLayout.swift */,
 			);
 			path = Source;
 			sourceTree = SOURCE_ROOT;
@@ -182,7 +186,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = ichigo;
 				TargetAttributes = {
 					2C7889C22116AC4900B26F02 = {
@@ -248,6 +252,7 @@
 				2C788A1D2116AF2E00B26F02 /* FullDateCollectionViewCell.swift in Sources */,
 				2C788A1E2116AF2E00B26F02 /* StepCollectionViewFlowLayout.swift in Sources */,
 				DE29D3F523C1B301007CC0F4 /* DateTimePicker+CollectionView.swift in Sources */,
+				966066EF2530AF7000427563 /* Bundle+Resource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -260,6 +265,7 @@
 				DE29D3F723C1B49F007CC0F4 /* DateTimePicker+CollectionView.swift in Sources */,
 				DE29D3F623C1B49C007CC0F4 /* DateTimePicker+UITableView.swift in Sources */,
 				DEF7C37A1D8B9F590043D9C4 /* DateTimePicker.swift in Sources */,
+				966066EE2530AF7000427563 /* Bundle+Resource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -293,7 +299,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = DateTimePicker/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ichigo.DateTimePicker;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -324,7 +330,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = DateTimePicker/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ichigo.DateTimePicker;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -360,6 +366,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -384,11 +391,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -416,6 +424,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -434,10 +443,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -451,7 +461,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2L9U9J29G7;
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ichigo.DateTimePickerDemo;
@@ -469,7 +479,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = T4WYNJ2VYX;
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ichigo.DateTimePickerDemo;

--- a/DateTimePicker.xcodeproj/xcshareddata/xcschemes/DateTimePicker.xcscheme
+++ b/DateTimePicker.xcodeproj/xcshareddata/xcschemes/DateTimePicker.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:DateTimePicker.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,21 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
 let package = Package(
     name: "DateTimePicker",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v10),
     ],
     products: [
-        .library(name: "DateTimePicker",  targets: ["DateTimePicker"])
+        .library(
+            name: "DateTimePicker",
+            targets: ["DateTimePicker"])
     ],
     dependencies: [],
     targets: [
-        .target(name: "DateTimePicker", path: "Source")
-    ],
-    swiftLanguageVersions: [.v5]
+        .target(
+            name: "DateTimePicker",
+            path: "Source")
+    ]
 )

--- a/Source/Bundle+Resource.swift
+++ b/Source/Bundle+Resource.swift
@@ -1,0 +1,46 @@
+//
+//  Bundle+Resource.swift
+//  DateTimePicker
+//
+//  Created by Duy Tran on 10/9/20.
+//
+
+import Foundation
+
+private class MyBundleFinder {}
+
+extension Foundation.Bundle {
+    
+    /**
+     The resource bundle associated with the current module..
+     - important: When `DateTimePicker` is distributed via Swift Package Manager, it will be synthesized automatically in the name of `Bundle.module`.
+     */
+    static var resource: Bundle = {
+        let moduleName = "DateTimePicker"
+        #if COCOAPODS
+        let bundleName = moduleName
+        #else
+        let bundleName = "\(moduleName)_\(moduleName)"
+        #endif
+        
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: MyBundleFinder.self).resourceURL,
+
+            // For command-line tools.
+            Bundle.main.bundleURL,
+        ]
+
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+        
+        fatalError("Unable to find bundle named \(bundleName)")
+    }()
+}

--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -288,17 +288,9 @@ public protocol DateTimePickerDelegate: class {
         }
     }
     
-    private static var resourceBundle: Bundle? {
-        let podBundle = Bundle(for: DateTimePicker.self)
-        guard let bundleURL = podBundle.url(forResource: "DateTimePicker", withExtension: "bundle") else {
-            return Bundle.main
-        }
-        return Bundle(url: bundleURL)
-    }
-    
     @objc open class func create(minimumDate: Date? = nil, maximumDate: Date? = nil) -> DateTimePicker {
          
-        guard let dateTimePicker = resourceBundle?.loadNibNamed("DateTimePicker", owner: nil, options: nil)?.first as? DateTimePicker else {
+        guard let dateTimePicker = Bundle.resource.loadNibNamed("DateTimePicker", owner: nil, options: nil)?.first as? DateTimePicker else {
             fatalError("Error loading nib")
         }
         dateTimePicker.minimumDate = minimumDate ?? Date(timeIntervalSinceNow: -3600 * 24 * 10)
@@ -418,7 +410,7 @@ public protocol DateTimePickerDelegate: class {
             layout.sectionInset = UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
             layout.itemSize = CGSize(width: 75, height: 80)
         }
-        dayCollectionView.register(UINib(nibName: "FullDateCollectionViewCell", bundle: DateTimePicker.resourceBundle), forCellWithReuseIdentifier: "dateCell")
+        dayCollectionView.register(UINib(nibName: "FullDateCollectionViewCell", bundle: .resource), forCellWithReuseIdentifier: "dateCell")
         dayCollectionView.dataSource = self
         dayCollectionView.delegate = self
         dayCollectionView.isHidden = isTimePickerOnly


### PR DESCRIPTION
Prior Swift tool 5.3, install this package via Swift Package Manager results in crashing every time invoking  `DateTimePicker`, because the resources file was not bundled.

## Description
Bundling resources when distributing via Swift Package Manager.

## How Has This Been Tested?

- Swift Package Manager:

1. Initiate playground project with the minimum iOS 10.
2. Install `DateTimePicker` as a local package.
2. Run unit tests.
3. Run UI tests.
5. Achrive.

- Cocoapods:

1. Initiate playground project with the minimum iOS 10.
2. Install `DateTimePicker` as a local package.
2. Run unit tests.
3. Run UI tests.
5. Archive.

- Carthage:

Supposed to running well like Cocoapods.

## Screenshots (if appropriate):
![Alt Text](https://media.giphy.com/media/a8CUTiCbdbeMerteaR/giphy.gif)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
