### PR TITLE
Using timeZone configuration in fact

### DIFF
--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -250,11 +250,13 @@ public protocol DateTimePickerDelegate: class {
     
     public var timeZone: TimeZone = .current {
         didSet {
+            guard calendar.timeZone != timeZone else { return }
             calendar.timeZone = timeZone
         }
     }
     public var calendar: Calendar = .current {
         didSet {
+            guard timeZone != calendar.timeZone else { return }
             timeZone = calendar.timeZone
         }
     }

--- a/Source/DateTimePicker.swift
+++ b/Source/DateTimePicker.swift
@@ -165,6 +165,7 @@ public protocol DateTimePickerDelegate: class {
         get {
             let formatter = DateFormatter()
             formatter.dateFormat = self.dateFormat
+            formatter.timeZone = self.timeZone
             return formatter.string(from: self.selectedDate)
         }
     }
@@ -247,8 +248,16 @@ public protocol DateTimePickerDelegate: class {
         }
     }
     
-    public var timeZone: TimeZone = .current
-    public var calendar: Calendar = .current
+    public var timeZone: TimeZone = .current {
+        didSet {
+            calendar.timeZone = timeZone
+        }
+    }
+    public var calendar: Calendar = .current {
+        didSet {
+            timeZone = calendar.timeZone
+        }
+    }
     public var hapticFeedbackEnabled: Bool = true
     
     public var completionHandler: ((Date)->Void)?
@@ -525,6 +534,7 @@ public protocol DateTimePickerDelegate: class {
         
         let formatter = DateFormatter()
         formatter.dateFormat = "dd/MM/YYYY"
+        formatter.timeZone = self.timeZone
         for i in 0..<dates.count {
             let date = dates[i]
             if formatter.string(from: date) == formatter.string(from: selectedDate) {
@@ -622,6 +632,7 @@ private extension DateTimePicker {
     func updateCollectionView(to currentDate: Date) {
         let formatter = DateFormatter()
         formatter.dateFormat = "dd/MM/YYYY"
+        formatter.timeZone = self.timeZone
         for i in 0..<dates.count {
             let date = dates[i]
             if formatter.string(from: date) == formatter.string(from: currentDate) {


### PR DESCRIPTION
At the moment it is possible to set custom timeZone, but this setting is never used by the DateTimePicker, .local is used everywhere instead.

This PR makes DateTimePicker respect the timeZone setting.

Also the calendar's timezone synced with timeZone, otherwise things would become weird in UI. There is two-way syncing between .timeZone and .calendar, just because we don't know which will be set by "user" during configuration.