### PR TITLE
Fixed in issue when the minutes and hours labels turned into dots on specific device with specific Text Size in preferences

### DIFF
--- a/Source/DateTimePicker+UITableView.swift
+++ b/Source/DateTimePicker+UITableView.swift
@@ -38,6 +38,7 @@ extension DateTimePicker: UITableViewDataSource, UITableViewDelegate {
         cell.textLabel?.font = customFontSetting.timeLabelFont
         cell.textLabel?.textColor = darkColor.withAlphaComponent(0.4)
         cell.textLabel?.highlightedTextColor = highlightColor
+        cell.textLabel?.adjustsFontSizeToFitWidth = true
         // add module operation to set value same
         if tableView == amPmTableView {
             cell.textLabel?.text = (indexPath.row == 0) ? "AM" : "PM"


### PR DESCRIPTION
The issue happened for me only on iPhone 12 mini with 5th and 6th levels of text size set in iOS Preferences.

Probably also the font size was close to the limit in my case. Even though everything was fine with simulator, other devices, and even on this same device with different text sizes set in settings. I was using font `UIFont(name: "Sunflower-Light", size: 24)`. But the issue could be potentially appearing with other fonts and in other circumstances.

![IMG_8053 copy](https://user-images.githubusercontent.com/5410835/118578691-458fe380-b795-11eb-98f3-dd509f15bc31.PNG)

![IMG_8054](https://user-images.githubusercontent.com/5410835/118578746-62c4b200-b795-11eb-9522-c5b839def3ad.PNG)


